### PR TITLE
update EasyTimezoneMiddleware.process_request

### DIFF
--- a/easy_timezones/middleware.py
+++ b/easy_timezones/middleware.py
@@ -150,12 +150,11 @@ class EasyTimezoneMiddleware(middleware_base_class):
         if tz:
             try:
                 timezone.activate(tz)
+                request.session['django_timezone'] = str(tz)
+                if getattr(settings, 'AUTH_USER_MODEL', None) and getattr(request, 'user', None):
+                    detected_timezone.send(sender=get_user_model(), instance=request.user, timezone=tz)
             except pytz.exceptions.UnknownTimeZoneError:
                 timezone.deactivate()
-
-            request.session['django_timezone'] = str(tz)
-            if getattr(settings, 'AUTH_USER_MODEL', None) and getattr(request, 'user', None):
-                detected_timezone.send(sender=get_user_model(), instance=request.user, timezone=tz)
-        else:
+       else:
             timezone.deactivate()
 


### PR DESCRIPTION
the previous PR (https://github.com/collabspot/django-easy-timezones/pull/1) was flawed. It should not execute anything after `timezone.activate(tz)` fails and It should also only execute https://github.com/collabspot/django-easy-timezones/blob/68b206178c6ddad63d74c5bfb8b91d8ccb8c10dc/easy_timezones/middleware.py#L153-L155 when the timezone is supported.